### PR TITLE
Automated: local package updates

### DIFF
--- a/system/nixos/pkgs/tipitaka-reader/default.nix
+++ b/system/nixos/pkgs/tipitaka-reader/default.nix
@@ -5,7 +5,7 @@
 }:
 let
   pname = "tipitaka_pali_reader";
-  version = "2.8.7+117";
+  version = "2.9.2+122";
   src = pkgs.fetchurl {
     # Add an explicit name property to fetchurl to lock the name of the `src` fixed output derivation
     # this prevents re-downloads when tweaking incidental settings


### PR DESCRIPTION
Opened automatically by nix-update-packages workflow. Review diffs before merging — hashes were refetched by nix-update.nix.